### PR TITLE
fix missing event

### DIFF
--- a/Token.sol
+++ b/Token.sol
@@ -26,6 +26,7 @@ contract Token {
         decimals = _decimals;
         totalSupply = _totalSupply; 
         balanceOf[msg.sender] = totalSupply;
+        emit Transfer(address(0), msg.sender, totalSupply);
     }
 
     /// @notice transfer amount of tokens to an address


### PR DESCRIPTION
based on the protocol, a Transfer event should be emitted.
“A token contract which creates new tokens SHOULD trigger a Transfer event with the _from address set to 0x0 when tokens are created.”
from https://eips.ethereum.org/EIPS/eip-20

So this fix just simply emits a transfer event when a new token is created.